### PR TITLE
Reduce the settings disk writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A sweet, short and subtle reminder that you might want to take a break from star
 - [x] Show total staring time (measured in increments of 1s whenever the plugin is active) in the status bar
 - [x] Allow customization of display text `You have been staring at your vault for $amount` (both total and current staring duration)
 - [x] Starting and stopping of the counter with a ribbon button
-- [x] Saving of the staring time is done every 10 minutes as well as on every settings change and when unloading the plugin to prevent too many disk writes
+- [x] Saving of the staring time is done every 10 minutes as well as on every settings change, when unloading the plugin and when starting/stopping the counter via the ribbon icon to prevent too many disk writes
 
 ## TODO
 - [ ] Implement `take a break` reminders, configurable

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A sweet, short and subtle reminder that you might want to take a break from star
 - [x] Show total staring time (measured in increments of 1s whenever the plugin is active) in the status bar
 - [x] Allow customization of display text `You have been staring at your vault for $amount` (both total and current staring duration)
 - [x] Starting and stopping of the counter with a ribbon button
+- [x] Saving of the staring time is done every 10 minutes as well as on every settings change and when unloading the plugin to prevent too many disk writes
 
 ## TODO
 - [ ] Implement `take a break` reminders, configurable

--- a/main.ts
+++ b/main.ts
@@ -40,10 +40,17 @@ export default class YouHaveBeenStaring extends Plugin {
                 this.showTimeSinceLoad(),
                 this.showTotalStaringTime(),
                 this.settings.totalUptime += this.counterActive ? 1000 : 0,
-                this.settings.currentSessionDuration += this.counterActive ? 1000 : 0,
-                this.saveSettings()
+                this.settings.currentSessionDuration += this.counterActive ? 1000 : 0
             }, 
                 1000
+        ));
+
+        // Save every 10 minutes
+        this.registerInterval(window.setInterval(() => 
+            {
+                this.saveSettings();
+            },
+            600000
         ));
 
         this.addSettingTab(new YouHaveBeenStaringSettingsTab(this.app, this));
@@ -51,7 +58,12 @@ export default class YouHaveBeenStaring extends Plugin {
         this.addRibbonIcon('any-key',  'Start/stop staring counter', () => {
             this.counterActive = !this.counterActive;
             new Notice('Turning staring counter ' + (this.counterActive ? 'on' : 'off'));
+            this.saveSettings();
 		});
+    }
+
+    onunload() {
+        this.saveSettings();
     }
 
     showTimeSinceLoad(): void {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "youhavebeenstaring-plugin",
 	"name": "YouHaveBeenStaring",
-	"version": "1.2.0",
+	"version": "1.2.1",
 	"minAppVersion": "0.9.12",
 	"description": "This plugin tells you in the status bar for how long you've been staring at your obsidian vault. Well - at least how long your vault is open.",
 	"author": "Felix Almer",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "youhavebeenstaring-plugin",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "This plugin tells you in the status bar for how long you've been staring at your obsidian vault. Well - at least how long your vault is open.",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
Do not save every counter increment but rather
- on plugin unload
- when starting/stopping the counter
- when changing a setting in the settings tab
- every 10min (in case obsidian is shut down)
